### PR TITLE
removed tidyverse library call 

### DIFF
--- a/inst/mypackage/inst/rmarkdown/templates/report/skeleton/skeleton.Rmd
+++ b/inst/mypackage/inst/rmarkdown/templates/report/skeleton/skeleton.Rmd
@@ -14,7 +14,6 @@ output          : mypackage::mypackage
 ```{r, include = FALSE}
 library(knitr)
 library(kableExtra)
-library(tidyverse)
 library(mypackage)
 cd_knit_chunk_opts()
 ```


### PR DESCRIPTION
from skeleton in order to not impose full tidyverse w/o need, fixes #24 .