### PR TITLE
Comment out cleveref since not used actively

### DIFF
--- a/inst/mypackage/inst/indiedown/preamble.tex
+++ b/inst/mypackage/inst/indiedown/preamble.tex
@@ -38,7 +38,9 @@
 \usepackage{units}
 
 % cross-references to according to the type of cross-reference
-\usepackage{cleveref}
+% comment out since not used (no \cref and company are found) and avoid conflicts with hyperref.
+% see section 14.1 of cleveref package: https://www.ctan.org/pkg/cleveref
+% \usepackage{cleveref}
 
 % Increase the number of simultaneous LaTeX floats
 \usepackage{morefloats}


### PR DESCRIPTION
Avoid conflicts with hyperref.

cleveref should make use of \cref and related functions, but it seems to me that any of those are used, so no need to load this package.

```
! Package cleveref Error: cleveref must be loaded after hyperref!.

Error: LaTeX failed to compile trial-cynkradown.tex. See https://yihui.org/tinytex/r/#debugging for debugging tips. See trial-cynkradown.log for more info.
Execution halted
```