### PR TITLE
Back to cleveref

### DIFF
--- a/inst/mypackage/inst/indiedown/preamble.tex
+++ b/inst/mypackage/inst/indiedown/preamble.tex
@@ -1,5 +1,10 @@
 % indiedown: customize additional LaTeX settings here
 
+% order is important here to avoid conflicts:
+% see section 14.1 of cleveref package: https://www.ctan.org/pkg/cleveref
+\usepackage{hyperref}
+\usepackage{cleveref}
+
 % word style tabs
 \usepackage{tabto}
 


### PR DESCRIPTION
Allow to use `\cref{}` and co. over base `\ref{}`.