### PR TITLE
chore: Apply air formatting, add `air.toml`

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -12,3 +12,4 @@
 ^cran-comments\.md$
 ^renovate\.json$
 ^\.ccache$
+^air\.toml$

--- a/R/create_indiedown_package.R
+++ b/R/create_indiedown_package.R
@@ -20,7 +20,10 @@ create_indiedown_package <- function(path, overwrite = FALSE) {
       stop("Path exists, use `overwrite = TRUE` to overwrite.", call. = FALSE)
     }
   } else if (fs::file_exists(path)) {
-    stop("Path exists and is a file or a link, remove before proceeding.", call. = FALSE)
+    stop(
+      "Path exists and is a file or a link, remove before proceeding.",
+      call. = FALSE
+    )
   }
 
   path_skeleton <- system.file("mypackage", package = "indiedown")
@@ -58,10 +61,14 @@ create_indiedown_package <- function(path, overwrite = FALSE) {
   writeLines(character(), ".here")
 
   cli_alert_success("indiedown skeleton set up at {.file {path}}")
-  cli_alert_info('See {.code vignette("indiedown")} for how to customize the {pkg_name} package')
+  cli_alert_info(
+    'See {.code vignette("indiedown")} for how to customize the {pkg_name} package'
+  )
 
   if (!rlang::is_installed("rmarkdown")) {
-    cli_alert_warning("Install the {.pkg rmarkdown} package to create documents from this template.")
+    cli_alert_warning(
+      "Install the {.pkg rmarkdown} package to create documents from this template."
+    )
   }
 
   invisible()

--- a/R/dr_down.R
+++ b/R/dr_down.R
@@ -8,21 +8,23 @@
 #'   indiedown::dr_down()
 #' }
 dr_down <- function() {
-
   # Check the version
   pandoc_v <- as.character(rmarkdown::pandoc_version())
   r_v <- paste(version$major, version$minor, sep = ".")
 
-  if (Sys.getenv("RSTUDIO") == "1" && requireNamespace("rstudioapi", quietly = TRUE)) {
+  if (
+    Sys.getenv("RSTUDIO") == "1" &&
+      requireNamespace("rstudioapi", quietly = TRUE)
+  ) {
     rstudio_v <- as.character(rstudioapi::versionInfo()$version)
   } else {
     rstudio_v <- NA_character_
   }
 
-  if(requireNamespace("tinytex", quietly = TRUE)){
+  if (requireNamespace("tinytex", quietly = TRUE)) {
     tinytex_v <- as.character(packageVersion("tinytex"))
     is_tinytex <- tinytex::is_tinytex()
-  } else{
+  } else {
     tinytex_v <- NA_character_
     is_tinytex <- FALSE
   }
@@ -67,7 +69,6 @@ dr_down <- function() {
   # clean up
   fs::dir_delete(tdir)
 
-
   cli_h1("System Information")
 
   cli_alert_info("R-Version: {version_info['r']}")
@@ -94,9 +95,12 @@ dr_down <- function() {
     cli_alert_info("Running outside of RStudio")
   }
 
-
   cli_h1("Test Runs")
-  text <- paste("Running", names(success), ifelse(success, "successfully", "unsuccessfully"))
+  text <- paste(
+    "Running",
+    names(success),
+    ifelse(success, "successfully", "unsuccessfully")
+  )
   for (i in seq_along(text)) {
     if (success[i]) {
       cli_alert_success(text[i])

--- a/R/use_indiedown_fonts.R
+++ b/R/use_indiedown_fonts.R
@@ -17,9 +17,11 @@
 #'   variants = c("regular", "italic", "700", "700italic")
 #' )
 #' }
-use_indiedown_gfonts <- function(path = ".",
-                                 id = "roboto",
-                                 variants = c("regular", "300italic", "700", "700italic")) {
+use_indiedown_gfonts <- function(
+  path = ".",
+  id = "roboto",
+  variants = c("regular", "300italic", "700", "700italic")
+) {
   path_fonts <- fs::path_norm(fs::path(path, "inst", "indiedown", "fonts"))
 
   fs::dir_create(path_fonts)

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,6 +1,8 @@
 gsub_in_file <- function(pattern, replacement, file, fixed = TRUE) {
   if (length(file) > 1) {
-    lapply(file, function(e) gsub_in_file(pattern, replacement, file = e, fixed = fixed))
+    lapply(file, function(e) {
+      gsub_in_file(pattern, replacement, file = e, fixed = fixed)
+    })
     return(invisible(TRUE))
   }
 

--- a/inst/mypackage/R/cd_format_date.R
+++ b/inst/mypackage/R/cd_format_date.R
@@ -9,7 +9,10 @@
 #' cd_format_date("2012-01-01", "de-DE")
 #' cd_format_date("2012-01-01", "en-US")
 #' @export
-cd_format_date <- function(date, lang = default(rmarkdown::metadata$lang, "en-US")) {
+cd_format_date <- function(
+  date,
+  lang = default(rmarkdown::metadata$lang, "en-US")
+) {
   date <- as.Date(date)
   if (lang %in% c("german", "de-DE", "de-CH")) {
     withr::with_locale(c("LC_TIME" = "de_DE"), format(date, "%e. %B %Y"))

--- a/inst/mypackage/R/cd_knit_chunk_opts.R
+++ b/inst/mypackage/R/cd_knit_chunk_opts.R
@@ -13,13 +13,14 @@
 #' cd_knit_chunk_opts()
 #'
 #' @export
-cd_knit_chunk_opts <- function(twocolumn = default(rmarkdown::metadata$twocolumn, FALSE),
-                               fig.width = NULL,
-                               fig.height = NULL,
-                               fig.pos = "h",
-                               message = FALSE,
-                               echo = FALSE) {
-
+cd_knit_chunk_opts <- function(
+  twocolumn = default(rmarkdown::metadata$twocolumn, FALSE),
+  fig.width = NULL,
+  fig.height = NULL,
+  fig.pos = "h",
+  message = FALSE,
+  echo = FALSE
+) {
   if (twocolumn) {
     fig.width <- default(fig.width, 4)
     fig.height <- default(fig.height, 3.5)

--- a/inst/mypackage/R/cd_page_title.R
+++ b/inst/mypackage/R/cd_page_title.R
@@ -12,10 +12,11 @@
 #'   title = "My Title",
 #'   subtitle = "My Subtitle"
 #' )
-cd_page_title <- function(title = default(rmarkdown::metadata$title, "Title"),
-                          subtitle = default(rmarkdown::metadata$subtitle, "Subtitle"),
-                          date = default(rmarkdown::metadata$date, cd_format_date(Sys.Date()))) {
-
+cd_page_title <- function(
+  title = default(rmarkdown::metadata$title, "Title"),
+  subtitle = default(rmarkdown::metadata$subtitle, "Subtitle"),
+  date = default(rmarkdown::metadata$date, cd_format_date(Sys.Date()))
+) {
   logo_path <- indiedown_path_tex("res/logo.png")
 
   indiedown_glue(

--- a/inst/mypackage/R/indiedown.R
+++ b/inst/mypackage/R/indiedown.R
@@ -3,12 +3,13 @@
 # do not customize this file!
 
 indiedown_pdf_document_with_asset <- function(includes = NULL, ...) {
-
   # file preamble
   if (file.exists(file.path(indiedown_path(), "preamble.tex"))) {
-
     file_preamble <- tempfile(fileext = ".tex")
-    txt <- readLines(file.path(indiedown_path(), "preamble.tex"), encoding = "UTF-8")
+    txt <- readLines(
+      file.path(indiedown_path(), "preamble.tex"),
+      encoding = "UTF-8"
+    )
     txt <- gsub("<<indiedown_path>>", indiedown_path_tex(), txt, fixed = TRUE)
     writeLines(txt, file_preamble)
 
@@ -16,7 +17,9 @@ indiedown_pdf_document_with_asset <- function(includes = NULL, ...) {
       includes <- rmarkdown::includes(in_header = file_preamble)
     } else {
       if ("in_header" %in% names(includes)) {
-        warning("The use of 'includes, in_header' overwrites preamble.tex from asset and may mess up the layout.")
+        warning(
+          "The use of 'includes, in_header' overwrites preamble.tex from asset and may mess up the layout."
+        )
       } else {
         includes$in_header <- file_preamble
       }
@@ -39,15 +42,30 @@ indiedown_pdf_document_with_asset <- function(includes = NULL, ...) {
   ans
 }
 
-pre_processor_basic <- function(metadata, input_file, runtime, knit_meta, files_dir, output_dir) {
+pre_processor_basic <- function(
+  metadata,
+  input_file,
+  runtime,
+  knit_meta,
+  files_dir,
+  output_dir
+) {
   args <- apply_default_yaml(metadata = metadata)
 }
 
 apply_default_yaml <- function(metadata) {
-  defaults_txt <- readLines(file.path(indiedown_path(), "default.yaml"), encoding = "UTF-8")
+  defaults_txt <- readLines(
+    file.path(indiedown_path(), "default.yaml"),
+    encoding = "UTF-8"
+  )
 
   # replace <<indiedown_path>> by package path
-  defaults_txt <- gsub("<<indiedown_path>>", indiedown_path_tex(), defaults_txt, fixed = TRUE)
+  defaults_txt <- gsub(
+    "<<indiedown_path>>",
+    indiedown_path_tex(),
+    defaults_txt,
+    fixed = TRUE
+  )
 
   defaults <- yaml::yaml.load(defaults_txt)
 
@@ -60,7 +78,14 @@ apply_default_yaml <- function(metadata) {
   # https://github.com/jgm/pandoc/issues/3139
   # we can still use `header-includes` by passing it as a command line option to pandoc
   if (!is.null(rmarkdown::metadata$`header-includes`)) {
-    args <- c(args, "--variable", paste0("header-includes:", paste(rmarkdown::metadata$`header-includes`, collapse = "\n")))
+    args <- c(
+      args,
+      "--variable",
+      paste0(
+        "header-includes:",
+        paste(rmarkdown::metadata$`header-includes`, collapse = "\n")
+      )
+    )
   }
 
   args
@@ -77,7 +102,9 @@ list_to_pandoc_args <- function(list) {
   is_character <- vapply(list, is.character, TRUE)
 
   # prepare logicals (TRUE FALSE to yes no)
-  list[is_logical] <- lapply(list[is_logical], function(x) ifelse(x, "yes", "no"))
+  list[is_logical] <- lapply(list[is_logical], function(x) {
+    ifelse(x, "yes", "no")
+  })
   # prepare character (comma separate multiple values)
   list[is_character] <- lapply(list[is_character], paste, collapse = ",")
 
@@ -150,7 +177,10 @@ indiedown_glue <- function(x, .open = "<<", .close = ">>") {
 
 # compatible with older versions. We can use raw strings from 4.0 on.
 read_tex <- function(file) {
-  paste(readLines(indiedown_path("tex", file), encoding = "UTF-8"), collapse = "\n")
+  paste(
+    readLines(indiedown_path("tex", file), encoding = "UTF-8"),
+    collapse = "\n"
+  )
 }
 
 #' Set Default Value

--- a/inst/mypackage/inst/indiedown/pre_processor.R
+++ b/inst/mypackage/inst/indiedown/pre_processor.R
@@ -1,16 +1,30 @@
 # indiedown: customize conditional settings here
 
-pre_processor <- function(metadata, input_file, runtime, knit_meta, files_dir, output_dir) {
-
+pre_processor <- function(
+  metadata,
+  input_file,
+  runtime,
+  knit_meta,
+  files_dir,
+  output_dir
+) {
   # apply default.yaml (do not remove)
   args <- apply_default_yaml(metadata = metadata)
 
   # set the margin based on twocolumn and wide
   if (is.null(metadata$geometry)) {
     if (isTRUE(metadata$twocolumn) || isTRUE(metadata$wide)) {
-      args <- c(args, "--variable", "geometry:top=1cm,bottom=1.75cm,left=2cm,right=2cm,includehead,includefoot")
+      args <- c(
+        args,
+        "--variable",
+        "geometry:top=1cm,bottom=1.75cm,left=2cm,right=2cm,includehead,includefoot"
+      )
     } else {
-      args <- c(args, "--variable", "geometry:top=1cm,bottom=1.75cm,left=2.5cm,right=2.5cm,includehead,includefoot")
+      args <- c(
+        args,
+        "--variable",
+        "geometry:top=1cm,bottom=1.75cm,left=2.5cm,right=2.5cm,includehead,includefoot"
+      )
     }
   }
 

--- a/tests/spelling.R
+++ b/tests/spelling.R
@@ -1,6 +1,7 @@
 if (requireNamespace("spelling", quietly = TRUE)) {
   spelling::spell_check_test(
-    vignettes = TRUE, error = FALSE,
+    vignettes = TRUE,
+    error = FALSE,
     skip_on_cran = TRUE
   )
 }

--- a/tests/testthat/test-create_indiedown_package.R
+++ b/tests/testthat/test-create_indiedown_package.R
@@ -8,7 +8,10 @@ test_that("create_indiedown_package() works", {
   withr::with_collate("C", sort(fs::dir_ls("mydown", recurse = TRUE)))
 
   unlink("mydown/R/cd_page_title.R")
-  expect_message(expect_message(create_indiedown_package("mydown", overwrite = TRUE)))
+  expect_message(expect_message(create_indiedown_package(
+    "mydown",
+    overwrite = TRUE
+  )))
 
   expect_true(file.exists("mydown/R/cd_page_title.R"))
 })


### PR DESCRIPTION
Formats all R sources with [air](https://posit-dev.github.io/air/) 0.10.0 and commits an `air.toml` (default settings, build-ignored) at the project root.

This is step I1 of the indiedown/cynkradown/zueridown alignment plan (tracked in `PLAN.md` in the cynkradown repo): zueridown is already air-formatted upstream, so a shared formatter baseline across all three repos makes every future template-vs-derived diff meaningful instead of style noise.

Covers `R/`, `tests/`, and — deliberately — the package skeleton sources in `inst/mypackage/R/` and `inst/mypackage/inst/indiedown/pre_processor.R`, so newly generated packages start out air-formatted. Formatting-only; no behavior changes. The `create_indiedown_package()` snapshot test compares file listings only and is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y54GejZ5mJPrmxVHkjk8um