### PR TITLE
fix: engine bugfixes and backports from derived packages

### DIFF
--- a/inst/mypackage/R/indiedown.R
+++ b/inst/mypackage/R/indiedown.R
@@ -77,13 +77,13 @@ apply_default_yaml <- function(metadata) {
   # pandoc ignores 'header-includes' if includes$in_header is specified
   # https://github.com/jgm/pandoc/issues/3139
   # we can still use `header-includes` by passing it as a command line option to pandoc
-  if (!is.null(rmarkdown::metadata$`header-includes`)) {
+  if (!is.null(metadata$`header-includes`)) {
     args <- c(
       args,
       "--variable",
       paste0(
         "header-includes:",
-        paste(rmarkdown::metadata$`header-includes`, collapse = "\n")
+        paste(metadata$`header-includes`, collapse = "\n")
       )
     )
   }

--- a/inst/mypackage/inst/indiedown/pre_processor.R
+++ b/inst/mypackage/inst/indiedown/pre_processor.R
@@ -8,6 +8,9 @@ pre_processor <- function(
   files_dir,
   output_dir
 ) {
+  # uncomment to require a recent pandoc (some asset packages rely on it)
+  # stopifnot(rmarkdown::pandoc_version() >= "3.1.5")
+
   # apply default.yaml (do not remove)
   args <- apply_default_yaml(metadata = metadata)
 
@@ -26,6 +29,18 @@ pre_processor <- function(
         "geometry:top=1cm,bottom=1.75cm,left=2.5cm,right=2.5cm,includehead,includefoot"
       )
     }
+  }
+
+  # pass twocolumn as classoption
+  if (isTRUE(metadata$twocolumn)) {
+    args <- c(
+      args,
+      "--variable",
+      paste0(
+        "classoption:",
+        paste(c(metadata$classoption, "twocolumn"), collapse = ",")
+      )
+    )
   }
 
   args


### PR DESCRIPTION
Implements plan item **I2** (tracked in cynkra/cynkradown#66).

## Changes

- **`inst/mypackage/R/indiedown.R`** — in `apply_default_yaml()`, read `header-includes` from the `metadata` argument rather than the global `rmarkdown::metadata` (2 occurrences). The global is empty during the pre-processor stage, so the old code silently dropped `header-includes`. This backports the post-2026-07 zueridown fix.
- **`inst/mypackage/inst/indiedown/pre_processor.R`**
  - Add a `twocolumn` → `classoption` block after the geometry block. It uses `paste(c(metadata$classoption, "twocolumn"), collapse = ",")` so an existing `classoption: landscape` yields `classoption:landscape,twocolumn`. The cynkradown/zueridown variants used `paste0("classoption:", metadata$classoption, "twocolumn", collapse = ",")`, which drops the comma — deliberately not copied.
  - Add a commented-out pandoc version guard (`# stopifnot(rmarkdown::pandoc_version() >= "3.1.5")`).

## Verification

- `devtools::test()` → `FAIL 0 | WARN 0 | SKIP 1 | PASS 11` (skeleton renders under lualatex/xelatex/pdflatex).
- Checked the classoption assembly: `classoption:landscape,twocolumn` when `classoption` is set, `classoption:twocolumn` when it is not (no leading comma).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015Jn2RnKcjauqkaXPEUGRWf)_