### PR TITLE
feat: unify `cd_format_date()` and `cd_knit_chunk_opts()` helpers

### DIFF
--- a/inst/mypackage/R/cd_format_date.R
+++ b/inst/mypackage/R/cd_format_date.R
@@ -1,10 +1,11 @@
 #' Corporate Design: Format Date
 #'
-#' Format date in local language format
+#' Format date in local language format.
 #'
-#' @param date Current date
-#' @param lang Language, either `"de-DE"`, `"de-CH"` or `"en_US"`
-#' @return Character string, date in local format
+#' @param date Current date.
+#' @param lang Language, e.g. `"de-DE"`, `"de-CH"` or `"en-US"`. Defaults to
+#'   the document's `lang` metadata field, or `"en-US"`.
+#' @return Character string, date in local format.
 #' @examples
 #' cd_format_date("2012-01-01", "de-DE")
 #' cd_format_date("2012-01-01", "en-US")
@@ -14,9 +15,49 @@ cd_format_date <- function(
   lang = default(rmarkdown::metadata$lang, "en-US")
 ) {
   date <- as.Date(date)
-  if (lang %in% c("german", "de-DE", "de-CH")) {
-    withr::with_locale(c("LC_TIME" = "de_DE"), format(date, "%e. %B %Y"))
+  if (lang %in% c("german", "ngerman", "de-DE", "de-CH")) {
+    withr::with_locale(
+      c("LC_TIME" = find_locale("de_DE")),
+      format(date, "%e. %B %Y")
+    )
   } else {
-    withr::with_locale(c("LC_TIME" = "en_US"), format(date, "%B %e, %Y"))
+    withr::with_locale(
+      c("LC_TIME" = find_locale("en_US")),
+      format(date, "%B %e, %Y")
+    )
   }
+}
+
+# Cache the list of installed locales; `locale -a` is slow to call repeatedly.
+available_locales <- (function() {
+  locales <- NULL
+  function() {
+    if (is.null(locales)) {
+      locales <<- system2("locale", "-a", stdout = TRUE)
+    }
+    locales
+  }
+})()
+
+# Resolve a locale name to an installed variant, preferring UTF-8. Errors with
+# a helpful message when the locale is missing, instead of silently
+# misformatting the date.
+find_locale <- function(main) {
+  locales <- available_locales()
+  utf8 <- grep(paste0(main, ".*utf"), locales, ignore.case = TRUE, value = TRUE)
+  if (length(utf8) > 0) {
+    return(utf8[[1]])
+  }
+
+  if (main %in% locales) {
+    warning(
+      "Using locale ",
+      main,
+      ", because UTF-8 variant not found.",
+      call. = FALSE
+    )
+    return(main)
+  }
+
+  stop("Can't find locale ", main, call. = FALSE)
 }

--- a/inst/mypackage/R/cd_knit_chunk_opts.R
+++ b/inst/mypackage/R/cd_knit_chunk_opts.R
@@ -1,31 +1,40 @@
 #' Corporate Design: knitr Chunk Options
 #'
-#' Set knitr chunk options in accordance with corporate design.
+#' Set knitr chunk options in accordance with corporate design. Figure
+#' dimensions default to sensible values chosen from the `twocolumn` and
+#' `wide` metadata fields; all other arguments are passed through to
+#' [knitr::opts_chunk].
 #'
-#' @param twocolumn Use two-column mode? This will affect `fig.width` and `fig.height`.
-#' @param fig.width Figure width. If `NULL`, automatically chosen based on `twocolumn`.
-#' @param fig.height Figure height If `NULL`, automatically chosen based on `twocolumn`.
-#' @param fig.pos Floating modifier for figures
+#' @param metadata Document metadata (YAML header); `twocolumn` and `wide`
+#'   determine the default figure dimensions.
+#' @param fig.width,fig.height Figure width/height in inches. If `NULL` (the
+#'   default), chosen automatically from `twocolumn`/`wide`.
+#' @param fig.pos Floating modifier for figures.
+#' @param cache Should chunk output be cached?
 #' @param message Should messages be shown?
-#' @param echo Should echo be shown?
-#' @return This function is called for its side effects and returns `NULL`, invisibly.
+#' @param echo Should source code be echoed?
+#' @param tidy Should source code be reformatted?
+#' @return This function is called for its side effects and returns `NULL`,
+#'   invisibly.
 #' @examples
 #' cd_knit_chunk_opts()
 #'
 #' @export
 cd_knit_chunk_opts <- function(
-  twocolumn = default(rmarkdown::metadata$twocolumn, FALSE),
+  metadata = rmarkdown::metadata,
   fig.width = NULL,
   fig.height = NULL,
   fig.pos = "h",
+  cache = FALSE,
   message = FALSE,
-  echo = FALSE
+  echo = FALSE,
+  tidy = FALSE
 ) {
-  if (twocolumn) {
+  if (isTRUE(metadata$twocolumn)) {
     fig.width <- default(fig.width, 4)
     fig.height <- default(fig.height, 3.5)
   } else {
-    if (isTRUE(rmarkdown::metadata$wide)) {
+    if (isTRUE(metadata$wide)) {
       fig.width <- default(fig.width, 8.5)
       fig.height <- default(fig.height, 3.38)
     } else {
@@ -37,8 +46,10 @@ cd_knit_chunk_opts <- function(
     fig.width = fig.width,
     fig.height = fig.height,
     fig.pos = fig.pos,
+    cache = cache,
     message = message,
-    echo = echo
+    echo = echo,
+    tidy = tidy
   )
 
   options(knitr.table.format = "latex")

--- a/inst/mypackage/man/cd_format_date.Rd
+++ b/inst/mypackage/man/cd_format_date.Rd
@@ -7,15 +7,16 @@
 cd_format_date(date, lang = default(rmarkdown::metadata$lang, "en-US"))
 }
 \arguments{
-\item{date}{Current date}
+\item{date}{Current date.}
 
-\item{lang}{Language, either \code{"de-DE"}, \code{"de-CH"} or \code{"en_US"}}
+\item{lang}{Language, e.g. \code{"de-DE"}, \code{"de-CH"} or \code{"en-US"}. Defaults to
+the document's \code{lang} metadata field, or \code{"en-US"}.}
 }
 \value{
-Character string, date in local format
+Character string, date in local format.
 }
 \description{
-Format date in local language format
+Format date in local language format.
 }
 \examples{
 cd_format_date("2012-01-01", "de-DE")

--- a/inst/mypackage/man/cd_knit_chunk_opts.Rd
+++ b/inst/mypackage/man/cd_knit_chunk_opts.Rd
@@ -5,32 +5,42 @@
 \title{Corporate Design: knitr Chunk Options}
 \usage{
 cd_knit_chunk_opts(
-  twocolumn = default(rmarkdown::metadata$twocolumn, FALSE),
+  metadata = rmarkdown::metadata,
   fig.width = NULL,
   fig.height = NULL,
   fig.pos = "h",
+  cache = FALSE,
   message = FALSE,
-  echo = FALSE
+  echo = FALSE,
+  tidy = FALSE
 )
 }
 \arguments{
-\item{twocolumn}{Use two-column mode? This will affect \code{fig.width} and \code{fig.height}.}
+\item{metadata}{Document metadata (YAML header); \code{twocolumn} and \code{wide}
+determine the default figure dimensions.}
 
-\item{fig.width}{Figure width. If \code{NULL}, automatically chosen based on \code{twocolumn}.}
+\item{fig.width, fig.height}{Figure width/height in inches. If \code{NULL} (the
+default), chosen automatically from \code{twocolumn}/\code{wide}.}
 
-\item{fig.height}{Figure height If \code{NULL}, automatically chosen based on \code{twocolumn}.}
+\item{fig.pos}{Floating modifier for figures.}
 
-\item{fig.pos}{Floating modifier for figures}
+\item{cache}{Should chunk output be cached?}
 
 \item{message}{Should messages be shown?}
 
-\item{echo}{Should echo be shown?}
+\item{echo}{Should source code be echoed?}
+
+\item{tidy}{Should source code be reformatted?}
 }
 \value{
-This function is called for its side effects and returns \code{NULL}, invisibly.
+This function is called for its side effects and returns \code{NULL},
+invisibly.
 }
 \description{
-Set knitr chunk options in accordance with corporate design.
+Set knitr chunk options in accordance with corporate design. Figure
+dimensions default to sensible values chosen from the \code{twocolumn} and
+\code{wide} metadata fields; all other arguments are passed through to
+\link[knitr:opts_chunk]{knitr::opts_chunk}.
 }
 \examples{
 cd_knit_chunk_opts()


### PR DESCRIPTION
Implements plan item **I3** (tracked in cynkra/cynkradown#67).

## Changes

- **`inst/mypackage/R/cd_format_date.R`** — ports `available_locales()` / `find_locale()` from cynkradown's `R/cd_format.R`. A missing locale now raises a helpful error (or warns and falls back to a non-UTF-8 variant) instead of silently misformatting the date. The `lang` default stays `default(rmarkdown::metadata$lang, "en-US")`, and `de_DE`/`en_US` remain the generic German/English locales (cynkradown overrides German to `de_CH`). `available_locales()` also gains the `<<-` cache assignment it needs to actually memoize `locale -a`.
- **`inst/mypackage/R/cd_knit_chunk_opts.R`** — adopts the superset signature `function(metadata = rmarkdown::metadata, fig.width = NULL, fig.height = NULL, fig.pos = "h", cache = FALSE, message = FALSE, echo = FALSE, tidy = FALSE)`, reads `twocolumn`/`wide` from `metadata`, and passes **every** argument through to `knitr::opts_chunk$set()`. The zueridown variant accepted the same arguments but hardcoded the values in the `set()` call — that bug is fixed here.
- Regenerated `man/cd_format_date.Rd` and `man/cd_knit_chunk_opts.Rd`.

## Verification

- `en-US` → `January  1, 2012`; German with a missing locale → `Can't find locale de_DE` (the intended helpful error).
- `cd_knit_chunk_opts(metadata = list(twocolumn = TRUE))` sets `fig.width = 4`; `cd_knit_chunk_opts(tidy = TRUE, echo = TRUE)` now actually propagates `tidy`/`echo`.
- `create_indiedown_package()` snapshot test: `FAIL 0 | PASS 9 | SKIP 1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015Jn2RnKcjauqkaXPEUGRWf)_