### PR TITLE
feat: read LaTeX title page from a tex snippet

### DIFF
--- a/inst/mypackage/R/cd_page_title.R
+++ b/inst/mypackage/R/cd_page_title.R
@@ -1,6 +1,8 @@
 #' Corporate Design: Title Page
 #'
-#' Example function to generate a title page
+#' Example function to generate a title page. The LaTeX lives in a snippet
+#' under `inst/indiedown/tex/page_title.tex`; this function reads it with
+#' `read_tex()` and interpolates the local variables via [indiedown_glue()].
 #'
 #' @param title Document title
 #' @param subtitle Document subtitle
@@ -19,29 +21,5 @@ cd_page_title <- function(
 ) {
   logo_path <- indiedown_path_tex("res/logo.png")
 
-  indiedown_glue(
-    # R >=4, raw strings allow to write LaTeX without escaping \ etc
-    r"(
-\vspace*{-1cm}
-\begin{center}
-  \makebox[\textwidth]{\includegraphics[width=0.1\paperwidth]{<<logo_path>>}}
-\end{center}
-
-
-\vspace*{2cm}
-
-\noindent \Huge <<title>>
-
-\noindent \huge <<subtitle>>
-
-\vspace*{2cm}
-
-
-\normalsize
-
-\noindent <<date>>
-
-\clearpage
-    )"
-  )
+  indiedown_glue(read_tex("page_title.tex"))
 }

--- a/inst/mypackage/inst/indiedown/tex/page_title.tex
+++ b/inst/mypackage/inst/indiedown/tex/page_title.tex
@@ -1,0 +1,20 @@
+\vspace*{-1cm}
+\begin{center}
+  \makebox[\textwidth]{\includegraphics[width=0.1\paperwidth]{<<logo_path>>}}
+\end{center}
+
+
+\vspace*{2cm}
+
+\noindent \Huge <<title>>
+
+\noindent \huge <<subtitle>>
+
+\vspace*{2cm}
+
+
+\normalsize
+
+\noindent <<date>>
+
+\clearpage

--- a/inst/mypackage/man/cd_page_title.Rd
+++ b/inst/mypackage/man/cd_page_title.Rd
@@ -21,7 +21,9 @@ cd_page_title(
 Object of class \code{"knit_asis"} (so that knitr will treat it as is). LaTeX code for title page.
 }
 \description{
-Example function to generate a title page
+Example function to generate a title page. The LaTeX lives in a snippet
+under \code{inst/indiedown/tex/page_title.tex}; this function reads it with
+\code{read_tex()} and interpolates the local variables via \code{\link[=indiedown_glue]{indiedown_glue()}}.
 }
 \examples{
 cd_page_title(

--- a/tests/testthat/_snaps/create_indiedown_package.md
+++ b/tests/testthat/_snaps/create_indiedown_package.md
@@ -29,6 +29,8 @@
       mydown/inst/indiedown/preamble.tex
       mydown/inst/indiedown/res
       mydown/inst/indiedown/res/logo.png
+      mydown/inst/indiedown/tex
+      mydown/inst/indiedown/tex/page_title.tex
       mydown/inst/rmarkdown
       mydown/inst/rmarkdown/templates
       mydown/inst/rmarkdown/templates/report

--- a/vignettes/customize.Rmd
+++ b/vignettes/customize.Rmd
@@ -81,6 +81,45 @@ Indiedown packages use R functions to generate LaTeX code for customization.
 
 For most customizations, it is recommended to turn off the default LaTeX title page, and create your own title page via LaTeX commands. The basic repertory are the LaTeX commands `\large`, `\Large`, `\LARGE`, `\huge`, etc, along with `vspace{1ex}`, but all LaTeX trickery can be applied. The LaTeX helper functions should be put in the `R` folder of your package.
 
+### Reusable LaTeX Snippets
+
+**Location:** `inst/indiedown/tex/` (optional)
+
+Longer blocks of LaTeX read better when they live in their own file rather than
+in an R raw string. Put such snippets under `inst/indiedown/tex/` and read them
+with `read_tex()`. Inside a snippet, `<<var>>` markers are interpolated by
+`indiedown_glue()` from the calling function's local variables (the same `<<`
+/ `>>` delimiters used elsewhere, chosen because braces are so common in
+LaTeX).
+
+For example, `cd_page_title()` keeps its layout in `tex/page_title.tex`:
+
+```
+\vspace*{-1cm}
+\begin{center}
+  \makebox[\textwidth]{\includegraphics[width=0.1\paperwidth]{<<logo_path>>}}
+\end{center}
+
+\noindent \Huge <<title>>
+\noindent \huge <<subtitle>>
+\noindent <<date>>
+\clearpage
+```
+
+and the R function only assigns the variables and hands the snippet to
+`indiedown_glue()`:
+
+```r
+cd_page_title <- function(title = ..., subtitle = ..., date = ...) {
+  logo_path <- indiedown_path_tex("res/logo.png")
+  indiedown_glue(read_tex("page_title.tex"))
+}
+```
+
+**Naming convention:** name generators `cd_page_*()` when they produce a full
+page (e.g. a title page, which usually ends with `\clearpage`) and
+`cd_header_*()` when they produce an in-page header.
+
 
 ## Templates
 


### PR DESCRIPTION
Implements plan item **I4** (tracked in cynkra/cynkradown#68).

## Changes

- Add **`inst/mypackage/inst/indiedown/tex/page_title.tex`** holding the title-page LaTeX.
- **`cd_page_title()`** keeps only its variable assignments and delegates the layout to `indiedown_glue(read_tex("page_title.tex"))`. The `<<logo_path>>`, `<<title>>`, `<<subtitle>>`, and `<<date>>` markers are interpolated from the calling frame — the same pattern as zueridown's `cd_footer()` + `tex/footer.tex`.
- Document the tex-snippet pattern in **`vignettes/customize.Rmd`**: snippets under `inst/indiedown/tex/`, `<<var>>` interpolation, and the naming convention (`cd_page_*()` = full pages, `cd_header_*()` = in-page headers).
- Regenerated `man/cd_page_title.Rd` and the `create_indiedown_package()` snapshot (adds the two `tex/` entries).

## Verification

- Generated a package with `create_indiedown_package()`, installed it, and called `cd_page_title(title = "T", subtitle = "S", date = "2026")` — the snippet is read and every `<<var>>` is interpolated (logo path resolved to the installed asset, `T`/`S`/`2026` substituted).
- `create_indiedown_package()` snapshot test: `FAIL 0 | PASS 9 | SKIP 1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015Jn2RnKcjauqkaXPEUGRWf)_