### PR TITLE
chore: skeleton hygiene

### DIFF
--- a/R/create_indiedown_package.R
+++ b/R/create_indiedown_package.R
@@ -42,6 +42,8 @@ create_indiedown_package <- function(path, overwrite = FALSE) {
     "inst/rmarkdown/templates/report/skeleton/skeleton.Rmd",
     "R/indiedown_pdf_document.R",
     "man/mypackage.Rd",
+    "tests/testthat.R",
+    "tests/testthat/test-render.R",
     "DESCRIPTION",
     "NAMESPACE"
   )
@@ -57,8 +59,10 @@ create_indiedown_package <- function(path, overwrite = FALSE) {
     file.path("man", paste0(pkg_name, ".Rd"))
   )
 
-  # Can't use .here as part of the template due to the leading dot
+  # Files with a leading dot are stripped from the built package, so they
+  # can't ship as part of the skeleton and must be written here instead.
   writeLines(character(), ".here")
+  writeLines("^air\\.toml$", ".Rbuildignore")
 
   cli_alert_success("indiedown skeleton set up at {.file {path}}")
   cli_alert_info(

--- a/inst/mypackage/DESCRIPTION
+++ b/inst/mypackage/DESCRIPTION
@@ -18,7 +18,11 @@ Imports:
     utils,
     withr,
     yaml
+Suggests:
+    kableExtra,
+    testthat (>= 3.0.0),
+    tinytex
 Encoding: UTF-8
-LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.1
+RoxygenNote: 7.3.2
+Config/testthat/edition: 3

--- a/inst/mypackage/inst/rmarkdown/templates/report/skeleton/skeleton.Rmd
+++ b/inst/mypackage/inst/rmarkdown/templates/report/skeleton/skeleton.Rmd
@@ -6,6 +6,8 @@ author          : ["My-Name", "Our-Team"]
 documentclass   : article   # article (default) report
 fontsize        : 11pt      # 10pt 11pt (default) 12pt
 numbersections  : true
+# twocolumn     : true      # false (default) true
+# lang          : en-US     # en-US (default) de-DE
 
 output          : mypackage::mypackage
 ---

--- a/inst/mypackage/tests/testthat.R
+++ b/inst/mypackage/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(mypackage)
+
+test_check("mypackage")

--- a/inst/mypackage/tests/testthat/test-render.R
+++ b/inst/mypackage/tests/testthat/test-render.R
@@ -1,0 +1,33 @@
+test_that("the report skeleton renders to PDF", {
+  skip_on_cran()
+  skip_if_not(
+    tinytex::is_tinytex() || nzchar(Sys.which("lualatex")),
+    "No TinyTeX / lualatex available"
+  )
+  skip_if_not_installed("kableExtra")
+
+  skeleton <- system.file(
+    "rmarkdown",
+    "templates",
+    "report",
+    "skeleton",
+    "skeleton.Rmd",
+    package = "mypackage"
+  )
+  skip_if(skeleton == "", "skeleton.Rmd not found")
+
+  dir <- withr::local_tempdir()
+  input <- file.path(dir, "skeleton.Rmd")
+  file.copy(skeleton, input)
+
+  output <- rmarkdown::render(
+    input,
+    output_dir = dir,
+    quiet = TRUE,
+    envir = new.env()
+  )
+
+  expect_true(file.exists(output))
+  expect_gt(file.info(output)$size, 0)
+  expect_identical(tolower(tools::file_ext(output)), "pdf")
+})

--- a/tests/testthat/_snaps/create_indiedown_package.md
+++ b/tests/testthat/_snaps/create_indiedown_package.md
@@ -17,6 +17,7 @@
       mydown/R/cd_page_title.R
       mydown/R/indiedown.R
       mydown/R/indiedown_pdf_document.R
+      mydown/air.toml
       mydown/inst
       mydown/inst/indiedown
       mydown/inst/indiedown/default.yaml
@@ -43,6 +44,10 @@
       mydown/man/indiedown_glue.Rd
       mydown/man/indiedown_path.Rd
       mydown/man/mydown.Rd
+      mydown/tests
+      mydown/tests/testthat
+      mydown/tests/testthat.R
+      mydown/tests/testthat/test-render.R
     Code
       unlink("mydown/R/cd_page_title.R")
       create_indiedown_package("mydown", overwrite = TRUE)


### PR DESCRIPTION
Implements plan item **I6** (tracked in cynkra/cynkradown#70).

## Changes

- **`inst/mypackage/DESCRIPTION`** — bump `RoxygenNote` to 7.3.2, drop `LazyData: true`, add `testthat (>= 3.0.0)`, `tinytex`, `kableExtra` to `Suggests`, and `Config/testthat/edition: 3`.
- **`inst/mypackage/air.toml`** — shipped in the skeleton (no leading dot, so it survives the build and `fs::dir_copy()`).
- **`R/create_indiedown_package.R`** — generate the skeleton `.Rbuildignore` (containing `^air\.toml$`) at creation time. Leading-dot files under `inst/` are stripped from the built package (verified: `.gitignore` is absent from the built tarball), so the file can't ship as skeleton data — same reason `.here` is written here. Also added the two new test files to the name-substitution `files` vector.
- **`skeleton.Rmd`** — commented `twocolumn:` and `lang:` YAML lines.
- **Skeleton render test** — `tests/testthat.R` + `tests/testthat/test-render.R` render `skeleton.Rmd` to PDF, skipping on CRAN and when no LaTeX engine / `kableExtra` is available.

## Verification

- Generated a package with `create_indiedown_package()`: it has `air.toml`, a generated `.Rbuildignore` (`^air\.toml$`), `tests/`, no `LazyData`, `RoxygenNote: 7.3.2`, and the test files correctly reference the generated package name.
- Installed the generated package and ran its render test → `FAIL 0 | WARN 0 | SKIP 0 | PASS 3` (skeleton renders to PDF).
- `create_indiedown_package()` snapshot test: `FAIL 0 | PASS 9 | SKIP 1`.

## Merge note

This PR and #105 (I7) both add an entry to the auto-generated `tests/testthat/_snaps/create_indiedown_package.md` right after `R/indiedown_pdf_document.R` (`air.toml` here, `R/kable_twocolumn.R` there), so whichever of the two merges **second** will hit a one-line conflict in that generated file. It is not a source/logic conflict — resolve by regenerating: `Rscript -e 'devtools::test(); testthat::snapshot_accept("create_indiedown_package")'`. All other indiedown PRs (#102, #103, #104, #106) merge in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)